### PR TITLE
load state from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ nitro-sdk
 mkds_c/external_include
 .clangd
 private
+states

--- a/src/main.py
+++ b/src/main.py
@@ -216,11 +216,11 @@ def worker():
 # ----------------------------
 # MAIN LOOP
 # ----------------------------
-def run_emulator(overlays):
+def run_emulator(overlays, state: str | None):
     global renderer, callback, emu_global, is_running
     emu = DeSmuME()
     emu.open("private/mariokart_ds.nds")
-    emu.savestate.load(0)
+    emu.savestate.load_file(f"states/{state or 'state'}.dst")
 
     emu_global = emu
     emu.volume_set(0)
@@ -285,4 +285,5 @@ if __name__ == "__main__":
             #distance_overlay,
             raycasting_overlay
         ],
+        sys.argv[1] if len(sys.argv) > 1 else None
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify which save state to load when launching the emulator using command-line arguments.
  * The emulator dynamically loads custom save states from specified file paths instead of relying on a default state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->